### PR TITLE
Update applicator_patch.rb and compatibility with redmine 5.0.2

### DIFF
--- a/lib/applicator_patch.rb
+++ b/lib/applicator_patch.rb
@@ -1,6 +1,6 @@
 require_dependency 'deface/applicator'
 
-module Deface
+module ApplicatorPatch
   module Applicator
     module ClassMethods
 


### PR DESCRIPTION
I suggest to change module Deface to module ApplicatorPatch

Under Redmine 5.0.2 it doesn't work with the Zeitwerk loader: 

	/usr/local/bundle/gems/zeitwerk-2.6.0/lib/zeitwerk/loader/callbacks.rb:25:in `on_file_autoloaded': expected file /usr/src/redmine/plugins/redmine_base_deface/lib/applicator_patch.rb to define constant ApplicatorPatch, but didn't (Zeitwerk::NameError)


      raise Zeitwerk::NameError.new("expected file #{file} to define constant #{cpath}, but didn't", cref.last)

      ^^^^^

	from /usr/local/bundle/gems/zeitwerk-2.6.0/lib/zeitwerk/kernel.rb:28:in `require'