### PR TITLE
Enable processing of DSL .deface files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.buildpath
+.byebug_history
+.metadata/
+.project
+Gemfile.lock
+config/
+db/
+files/
+log/
+public/
+tmp/
+

--- a/PluginGemfile
+++ b/PluginGemfile
@@ -1,1 +1,1 @@
-gem 'deface', '1.3.2'
+gem 'deface', '1.5.3'

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ Redmine::Plugin.register :redmine_base_deface do
   name 'Redmine Base Deface plugin'
   author 'Jean-Baptiste BARTH'
   description 'This is a plugin for Redmine'
-  version '1.3.2'
+  version '1.5.3'
   url 'https://github.com/jbbarth/redmine_base_deface'
   author_url 'jeanbaptiste.barth@gmail.com'
   #doesn't work since redmine evaluates dependencies as it loads, and loads in lexical order

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ Redmine::Plugin.register :redmine_base_deface do
   name 'Redmine Base Deface plugin'
   author 'Jean-Baptiste BARTH'
   description 'This is a plugin for Redmine'
-  version '1.6.2'
+  version '5.0.6'
   url 'https://github.com/jbbarth/redmine_base_deface'
   author_url 'jeanbaptiste.barth@gmail.com'
   #doesn't work since redmine evaluates dependencies as it loads, and loads in lexical order


### PR DESCRIPTION
Implementation for Rails 6 only loads the .rb files. DSL .deface overrides were ignored.