### PR TITLE
Fix using classic autoloader in Rails 6.x

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -14,7 +14,11 @@ end
 # - redmine plugins are not railties nor engines, so deface overrides are not detected automatically
 # - deface doesn't support direct loading anymore ; it unloads everything at boot so that reload in dev works
 # - hack consists in adding "app/overrides" path of all plugins in Redmine's main #paths
-if Rails.version > '6.0'
+
+# Select the autoloader to use: zeitwerk or the classic one
+# The `zeitwerk_enabled?` predicate returns `true` for Rails >= 7
+# For Rails 6.x, it returns `Rails.configuration.autoloader == :zeitwerk`
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
   Dir.glob("#{Rails.root}/plugins/*/app/overrides/**/*.rb").each do |path|
     Rails.autoloaders.main.ignore(path)
     load File.expand_path(path, __FILE__)


### PR DESCRIPTION
While Rails up to 5 will use the classic autoloader and Rails 7+ will use zeitwerk, Rails 6.x can still be configured to use the classic autoloader: in that case, the code with throw an exception as it expects the latter behavior.

By adding a call to `zeitwerk_enabled?`, we support both cases, while having no impact on other Rails versions.

See [Rails 7's](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#rails-autoloaders) and [Rails 6's](https://guides.rubyonrails.org/v6.0/autoloading_and_reloading_constants.html#opting-out) docs for more information.